### PR TITLE
Suggestions to big PR

### DIFF
--- a/contracts/DynamicNFT.cdc
+++ b/contracts/DynamicNFT.cdc
@@ -1,0 +1,52 @@
+// import NonFungibleToken from "./utility/NonFungibleToken.cdc" 
+
+pub contract DynamicNFT {
+
+    /// An interface for a resource defining the Type that an attachment is
+    /// designed to be attached to
+    ///
+    pub resource interface Attachment {
+        pub let nftID: UInt64
+        pub let attachmentFor: [Type]
+    }
+
+    pub resource interface Dynamic /*: NonFungibleToken.INFT*/ {
+
+        access(contract) let attachments: @{Type: AnyResource{Attachment}}
+
+        pub fun addAttachment(_ attachment: @AnyResource{Attachment}) {
+            pre {
+                !self.hasAttachmentType(attachment.getType()):
+                    "NFT already contains attachment of this type!"
+            }
+        }
+
+        /// Function revealing whether NFT has an attachment of the given Type
+        ///
+        /// @param type: The type in question
+        ///
+        /// @return true if NFT has given Type attached and false otherwise
+        ///
+        pub fun hasAttachmentType(_ type: Type): Bool {
+            return self.attachments.containsKey(type)
+        }
+
+        /// Returns a reference to the attachment of the given Type
+        ///
+        /// @param type: Type of the desired attachment reference
+        ///
+        /// @return Generic auth reference ready for downcasting
+        ///
+        pub fun getAttachmentRef(_ type: Type): auth &AnyResource? {
+            return &self.attachments[type] as auth &AnyResource?
+        }
+
+        /// Getter method for array of types attached to this NFT
+        ///
+        /// @return array of attached Types
+        ///
+        pub fun getAttachmentTypes(): [Type] {
+            return self.attachments.keys
+        }
+    }
+}

--- a/contracts/GamingMetadataViews.cdc
+++ b/contracts/GamingMetadataViews.cdc
@@ -8,20 +8,31 @@ import MetadataViews from "./utility/MetadataViews.cdc"
 /// 
 pub contract GamingMetadataViews {
 
-    /// Interface that should be implemented by game contracts
-    /// which returns BasicWinLoss data of given NFT.id
-    /// The implementing resource expose a capability which
-    /// is added to the escrowed NFT so that the BasicWinloss
-    /// stored on the game contract can be retrieved by the NFT
+    /// A struct defining metadata relevant to a game
     ///
-    pub resource interface BasicWinLossRetriever {
+    pub struct GameContractMetadata {
+        pub let name: String
+        pub let description: String
+        pub let icon: AnyStruct{MetadataViews.File}
+        pub let thumbnail: AnyStruct{MetadataViews.File}
+        pub let contractAddress: Address
+        pub let externalURL: MetadataViews.ExternalURL
         
-        /// Retrieves the BasicWinLoss for a given NFT
-        ///
-        /// @param nftID: The id of the NFT the caller is attempting to
-        /// retrieve a BasicWinLoss for
-        ///
-        pub fun getWinLossData(nftID: UInt64): BasicWinLoss?
+        init(
+            name: String,
+            description: String,
+            icon: AnyStruct{MetadataViews.File},
+            thumbnail: AnyStruct{MetadataViews.File},
+            contractAddress: Address,
+            externalURL: MetadataViews.ExternalURL
+        ) {
+            self.name = name
+            self.description = description
+            self.icon = icon
+            self.thumbnail = thumbnail
+            self.contractAddress = contractAddress
+            self.externalURL = externalURL
+        }
     }
 
     /// Struct that contains attributes and methods relevant to win/loss/tie
@@ -84,52 +95,32 @@ pub contract GamingMetadataViews {
             }
             self.ties = self.ties - 1
         }
-    }
 
-    /// A struct defining metadata relevant to a game
-    ///
-    pub struct GameContractMetadata {
-        pub let name: String
-        pub let description: String
-        pub let icon: AnyStruct{MetadataViews.File}
-        pub let thumbnail: AnyStruct{MetadataViews.File}
-        pub let contractAddress: Address
-        pub let externalURL: MetadataViews.ExternalURL
-        
-        init(
-            name: String,
-            description: String,
-            icon: AnyStruct{MetadataViews.File},
-            thumbnail: AnyStruct{MetadataViews.File},
-            contractAddress: Address,
-            externalURL: MetadataViews.ExternalURL
-        ) {
-            self.name = name
-            self.description = description
-            self.icon = icon
-            self.thumbnail = thumbnail
-            self.contractAddress = contractAddress
-            self.externalURL = externalURL
+        pub fun reset() {
+            self.wins = 0
+            self.losses = 0
+            self.ties = 0
         }
     }
 
-    /** --- Attachment Interfaces --- */
-
-    /// Interface defining a resource that can have attachments added to it
+    /// Interface that should be implemented by game contracts
+    /// which returns BasicWinLoss data of given NFT.id
+    /// The implementing resource expose a capability which
+    /// is added to the escrowed NFT so that the BasicWinLoss
+    /// stored on the game contract can be retrieved by the NFT
     ///
-    pub resource interface Attachable {
-        access(contract) let attachments: @{Type: AnyResource{Attachment}}
-        pub fun addAttachment(_ attachment: @AnyResource{Attachment}) 
-        pub fun hasAttachmentType(_ type: Type): Bool
-        pub fun getAttachmentRef(_ type: Type): auth &AnyResource?
-        pub fun getAttachmentTypes(): [Type]
-    }
+    pub resource interface BasicWinLossRetriever {
+        
+        /// Retrieves the BasicWinLoss for a given NFT
+        ///
+        /// @param nftID: The id of the NFT the caller is attempting to
+        /// retrieve a BasicWinLoss for
+        ///
+        pub fun getWinLossData(): BasicWinLoss?
 
-    /// An interface for a resource defining the Type that an attachment is
-    /// designed to be attached to
-    ///
-    pub resource interface Attachment {
-        pub let attachmentFor: [Type]
+        /// Allows the owner to reset the WinLoss records of the NFT where this is attached
+        ///
+        pub fun resetWinLossData()
     }
 
     /// A resource interface defining an attachment representative of a simple

--- a/scripts/get_rps_win_loss.cdc
+++ b/scripts/get_rps_win_loss.cdc
@@ -20,7 +20,7 @@ pub fun main(address: Address, id: UInt64): GamingMetadataViews.BasicWinLoss? {
             // Cast returned AnyResource as RPSWinLossRetriever & return the 
             // BasicWinLoss value for given NFT
             let retrieverRef = attachmentRef as! &RockPaperScissorsGame.RPSWinLossRetriever
-            return retrieverRef.getWinLossData(nftID: id)
+            return retrieverRef.getWinLossData()
         }
     }
 


### PR DESCRIPTION
Closes: #27

## Description
Moves the `Attachment` resource interface to a new `DynamicNFT` contract.
Merges the `Attachable` and `NFTPublic` resource interfaces into the `Dynamic` resource interface included in the `DynamicNFT` contract.
Removes the `nftID` parameter from the retriever function so an NFT can only retrieve its own records.
Adds the `resetWinLossRecords()` method to the retriever.


______

For contributor use:

- [x] Targeted PR against `player-custodied-async` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 